### PR TITLE
fix live grep

### DIFF
--- a/modules/folding.nix
+++ b/modules/folding.nix
@@ -54,10 +54,10 @@
       foldminlines = 9;
     };
 
-    extraConfigVim = ''
-      autocmd BufWinLeave * mkview
-      autocmd BufWinEnter * silent! loadview
-    '';
+    extraConfigVim = "
+      autocmd BufWinLeave * if &buftype != 'nofile' && expand('%') != '' | mkview | endif
+      autocmd BufWinEnter * if &buftype != 'nofile' && expand('%') != '' | silent! loadview | endif
+    ";
 
     plugins.treesitter.enable = true;
     plugins.treesitter.folding = true;


### PR DESCRIPTION
some buffers are actually not files, so they need to be excluded

this pr fixes this:
![image](https://github.com/user-attachments/assets/cde28f12-3a01-47e0-90df-2b529e15f33d)
